### PR TITLE
`PriorityQueue` の実装

### DIFF
--- a/Sources/AtCoderSupport/PriorityQueue.swift
+++ b/Sources/AtCoderSupport/PriorityQueue.swift
@@ -1,0 +1,66 @@
+struct PriorityQueue<Element> {
+    private var elements: [Element] = []
+    private let areInIncreasingOrder: (Element, Element) -> Bool
+    
+    init<S>(_ elements: S, by areInIncreasingOrder: @escaping (Element, Element) -> Bool) where S: Sequence, S.Element == Element {
+        self.areInIncreasingOrder = areInIncreasingOrder
+        for element in elements {
+            append(element)
+        }
+    }
+    
+    init(by areInIncreasingOrder: @escaping (Element, Element) -> Bool) {
+        self.init(EmptyCollection(), by: areInIncreasingOrder)
+    }
+    
+    init<S>(_ elements: S) where S: Sequence, S.Element == Element, Element: Comparable {
+        self.init(elements, by: <)
+    }
+    
+    init() where Element: Comparable {
+        self.init(by: <)
+    }
+    
+    var isEmpty: Bool { elements.isEmpty }
+    var count: Int { elements.count }
+    var first: Element? { elements.first }
+    
+    mutating func append(_ element: Element) {
+        var i = elements.count
+        elements.append(element)
+        while i > 0 {
+            let parentIndex = (i - 1) >> 1
+            guard areInIncreasingOrder(element, elements[parentIndex]) else { break }
+            elements.swapAt(i, parentIndex)
+            i = parentIndex
+        }
+    }
+    
+    mutating func popFirst() -> Element? {
+        if elements.isEmpty { return nil }
+        elements.swapAt(0, elements.count - 1)
+        let first = elements.removeLast()
+        if elements.isEmpty { return first }
+        
+        let element = elements[0]
+        var  i = 0
+        while true {
+            var childIndex: Int = (i << 1) + 1
+            guard childIndex < elements.count else { break }
+            var child: Element = elements[childIndex]
+            let rightIndex = childIndex + 1
+            if rightIndex < elements.count {
+                let right = elements[rightIndex]
+                if areInIncreasingOrder(right, child) {
+                    childIndex = rightIndex
+                    child = right
+                }
+            }
+            if areInIncreasingOrder(element, child) { break }
+            elements.swapAt(i, childIndex)
+            i = childIndex
+        }
+
+        return first
+    }
+}

--- a/Sources/AtCoderSupport/PriorityQueue.swift
+++ b/Sources/AtCoderSupport/PriorityQueue.swift
@@ -28,38 +28,43 @@ struct PriorityQueue<Element> {
     mutating func append(_ element: Element) {
         var i = elements.count
         elements.append(element)
-        while i > 0 {
-            let parentIndex = (i - 1) >> 1
-            let parent = elements[parentIndex]
-            guard areInIncreasingOrder(element, parent) else { break }
-            elements[parentIndex] = element
-            elements[i] = parent
-            i = parentIndex
+        elements.withUnsafeMutableBufferPointer { elements in
+            while i > 0 {
+                let parentIndex = (i - 1) >> 1
+                let parent = elements[parentIndex]
+                guard areInIncreasingOrder(element, parent) else { break }
+                elements[parentIndex] = element
+                elements[i] = parent
+                i = parentIndex
+            }
         }
     }
     
     mutating func popFirst() -> Element? {
         guard let element = elements.popLast() else { return nil }
         guard let first = elements.first else { return element }
-        elements[0] = element
         
-        var  i = 0
-        while true {
-            var childIndex: Int = (i << 1) + 1
-            guard childIndex < elements.count else { break }
-            var child: Element = elements[childIndex]
-            let rightIndex = childIndex + 1
-            if rightIndex < elements.count {
-                let right = elements[rightIndex]
-                if areInIncreasingOrder(right, child) {
-                    childIndex = rightIndex
-                    child = right
+        elements.withUnsafeMutableBufferPointer { elements in
+            elements[0] = element
+            
+            var  i = 0
+            while true {
+                var childIndex: Int = (i << 1) + 1
+                guard childIndex < elements.count else { break }
+                var child: Element = elements[childIndex]
+                let rightIndex = childIndex + 1
+                if rightIndex < elements.count {
+                    let right = elements[rightIndex]
+                    if areInIncreasingOrder(right, child) {
+                        childIndex = rightIndex
+                        child = right
+                    }
                 }
+                if areInIncreasingOrder(element, child) { break }
+                elements[childIndex] = element
+                elements[i] = child
+                i = childIndex
             }
-            if areInIncreasingOrder(element, child) { break }
-            elements[childIndex] = element
-            elements[i] = child
-            i = childIndex
         }
 
         return first

--- a/Sources/AtCoderSupport/PriorityQueue.swift
+++ b/Sources/AtCoderSupport/PriorityQueue.swift
@@ -13,14 +13,6 @@ struct PriorityQueue<Element> {
         self.init(EmptyCollection(), by: areInIncreasingOrder)
     }
     
-    init<S>(_ elements: S) where S: Sequence, S.Element == Element, Element: Comparable {
-        self.init(elements, by: <)
-    }
-    
-    init() where Element: Comparable {
-        self.init(by: <)
-    }
-    
     var isEmpty: Bool { elements.isEmpty }
     var count: Int { elements.count }
     var first: Element? { elements.first }
@@ -69,4 +61,14 @@ struct PriorityQueue<Element> {
 
         return first
     }
+}
+extension PriorityQueue where Element: Comparable {
+    init<S>(_ elements: S) where S: Sequence, S.Element == Element {
+        self.init(elements, by: <)
+    }
+    
+    init() {
+        self.init(by: <)
+    }
+    
 }

--- a/Sources/AtCoderSupport/PriorityQueue.swift
+++ b/Sources/AtCoderSupport/PriorityQueue.swift
@@ -30,19 +30,19 @@ struct PriorityQueue<Element> {
         elements.append(element)
         while i > 0 {
             let parentIndex = (i - 1) >> 1
-            guard areInIncreasingOrder(element, elements[parentIndex]) else { break }
-            elements.swapAt(i, parentIndex)
+            let parent = elements[parentIndex]
+            guard areInIncreasingOrder(element, parent) else { break }
+            elements[parentIndex] = element
+            elements[i] = parent
             i = parentIndex
         }
     }
     
     mutating func popFirst() -> Element? {
-        if elements.isEmpty { return nil }
-        elements.swapAt(0, elements.count - 1)
-        let first = elements.removeLast()
-        if elements.isEmpty { return first }
+        guard let element = elements.popLast() else { return nil }
+        guard let first = elements.first else { return element }
+        elements[0] = element
         
-        let element = elements[0]
         var  i = 0
         while true {
             var childIndex: Int = (i << 1) + 1
@@ -57,7 +57,8 @@ struct PriorityQueue<Element> {
                 }
             }
             if areInIncreasingOrder(element, child) { break }
-            elements.swapAt(i, childIndex)
+            elements[childIndex] = element
+            elements[i] = child
             i = childIndex
         }
 

--- a/Tests/AtCoderSupportTests/PriorityQueueTests.swift
+++ b/Tests/AtCoderSupportTests/PriorityQueueTests.swift
@@ -1,0 +1,113 @@
+import XCTest
+@testable import AtCoderSupport
+
+final class PriorityQueueTests: XCTestCase {
+    func testAppend() {
+        do {
+            var queue: PriorityQueue<Int> = .init([3, 7, 2, 8, 5, 2])
+            
+            XCTAssertEqual(queue.first, 2)
+            XCTAssertEqual(queue.count, 6)
+            
+            queue.append(1)
+            
+            XCTAssertEqual(queue.first, 1)
+            XCTAssertEqual(queue.count, 7)
+            
+            queue.append(4)
+            
+            XCTAssertEqual(queue.first, 1)
+            XCTAssertEqual(queue.count, 8)
+
+            queue.append(1)
+            
+            XCTAssertEqual(queue.first, 1)
+            XCTAssertEqual(queue.count, 9)
+
+            queue.append(0)
+            
+            XCTAssertEqual(queue.first, 0)
+            XCTAssertEqual(queue.count, 10)
+        }
+        do {
+            var queue: PriorityQueue<Int> = .init()
+           
+            XCTAssertEqual(queue.isEmpty, true)
+            
+            let elements = Array(1 ... 100).shuffled()
+            for (i, element) in elements.enumerated() {
+                XCTAssertEqual(queue.count, i)
+                XCTAssertEqual(queue.first, elements[0 ..< i].min())
+                
+                queue.append(element)
+                
+                XCTAssertEqual(queue.isEmpty, false)
+            }
+            
+            XCTAssertEqual(queue.count, elements.count)
+        }
+    }
+    
+    func testPopFirst() {
+        do {
+            var queue: PriorityQueue<Int> = .init([5, 9, 2, 0, 3, 6, 2, 5])
+            
+            XCTAssertEqual(queue.popFirst(), 0)
+            XCTAssertEqual(queue.popFirst(), 2)
+            XCTAssertEqual(queue.popFirst(), 2)
+            XCTAssertEqual(queue.popFirst(), 3)
+            XCTAssertEqual(queue.popFirst(), 5)
+            XCTAssertEqual(queue.popFirst(), 5)
+            XCTAssertEqual(queue.popFirst(), 6)
+            XCTAssertEqual(queue.popFirst(), 9)
+            XCTAssertEqual(queue.popFirst(), nil)
+        }
+        do {
+            var queue: PriorityQueue<Int> = .init()
+            XCTAssertEqual(queue.popFirst(), nil)
+        }
+        do {
+            var elements = Array(1 ... 100).shuffled()
+            var queue: PriorityQueue<Int> = .init(elements)
+            elements.sort()
+            
+            for (i, element) in elements.enumerated() {
+                XCTAssertEqual(queue.count, elements.count - i)
+                XCTAssertEqual(queue.isEmpty, false)
+                XCTAssertEqual(queue.first, element)
+                XCTAssertEqual(queue.popFirst(), element)
+            }
+            
+            XCTAssertEqual(queue.count, 0)
+            XCTAssertEqual(queue.isEmpty, true)
+            XCTAssertEqual(queue.first, nil)
+            XCTAssertEqual(queue.popFirst(), nil)
+        }
+    }
+    
+    #if !DEBUG
+    func testAppendPerformance() {
+        let elements = (1 ... 100_000).shuffled()
+        measure {
+            var queue: PriorityQueue<Int> = .init()
+            for element in elements {
+                queue.append(element)
+            }
+            XCTAssertEqual(queue.count, elements.count)
+        }
+    }
+    
+    func testPopFirstPerformance() {
+        let elements = (1 ... 100_000).shuffled()
+        let queue: PriorityQueue<Int> = .init(elements)
+        measure {
+            var queue = queue
+            while !queue.isEmpty {
+                _ = queue.popFirst()
+            }
+            XCTAssertTrue(queue.isEmpty)
+        }
+
+    }
+    #endif
+}


### PR DESCRIPTION
#2 でも必要とされている `PrioriryQueue` を二分ヒープで実装しました。

Swift 標準ライブラリの `ArraySlice` や、本ライブラリの `Deque` に倣って、要素を追加するメソッド名を `append` 、要素を取り出すメソッド名を `popFirst` としました。

`Sequence` に適合させることもできますが、全要素取得に O(N log N) かかってしまうので O(N) を期待している利用側からするとミスリーディングなことと、やりたければ↓のようにできるので `Sequence` への適合はやめました。

```swift
while let element = queue.popFirst() {
    // ...
}
```

`Array` の `swapAt` が思ったより遅かったので、 `withUnsafeBufferPointer` を挟むことで高速化しました。