### PR TITLE
`UnionFind` の実装

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Swift Package 形式になっていますが、 AtCoder で利用する際には
 | 深さ優先探索 | `dfs(edges:startedAt:_:)` | [ABC 138 D - Ki](https://atcoder.jp/contests/abc138/submissions/17546144) |
 | 素数判定 | `isPrime` | [ABC 149 C - Next Prime](https://atcoder.jp/contests/abc149/submissions/17548101) |
 | 巡回セールスマン問題 | `tsp(distances:startedAt:)` | [ABC 180 E - Traveling Salesman among Aerial Cities](https://atcoder.jp/contests/abc180/submissions/17561600) |
+| Union-Find | `UnionFind` | [ARC 032 B - 道路工事](https://atcoder.jp/contests/arc032/submissions/17591100) |
 
 ## テスト
 

--- a/Sources/AtCoderSupport/UnionFind.swift
+++ b/Sources/AtCoderSupport/UnionFind.swift
@@ -11,8 +11,13 @@ struct UnionFind {
     }
 
     func root(of i: Int) -> Int {
-        if parents[i] == i { return i }
-        return root(of: parents[i])
+        var current = i
+        while true {
+            let parent = parents[current]
+            if current == parent { break }
+            current = parent
+        }
+        return current
     }
 
     mutating func unite(_ x: Int, _ y: Int) {

--- a/Sources/AtCoderSupport/UnionFind.swift
+++ b/Sources/AtCoderSupport/UnionFind.swift
@@ -34,7 +34,7 @@ struct UnionFind {
         }
     }
 
-    func areSame(_ x: Int, _ y: Int) -> Bool {
+    func areInSameSet(_ x: Int, _ y: Int) -> Bool {
         root(of:x) == root(of:y)
     }
 }

--- a/Sources/AtCoderSupport/UnionFind.swift
+++ b/Sources/AtCoderSupport/UnionFind.swift
@@ -1,0 +1,39 @@
+struct UnionFind {
+    var par:[Int]
+    var rank:[Int]
+    var n:Int
+    init(n:Int){
+        self.n = n
+        self.par = Array(repeating:0,count:n)
+        self.rank = Array(repeating:0,count:n)
+        for i in 0..<n{
+            par[i] = i
+        }
+    }
+    mutating func root(x:Int) -> Int {
+        if par[x] == x{
+            return x
+        }
+        else{
+            return root(x:par[x])
+        }
+    }
+    mutating func unite (x:Int,y:Int){
+        let x = root(x:x)
+        let y = root(x:y)
+        if x == y{
+            return
+        }
+        if rank[x] < rank[y]{
+            par[x] = y
+        } else {
+            par[y] = x
+            if rank[x] == rank[y]{
+                rank[x] += 1
+            }
+        }
+    }
+    mutating func same(x:Int,y:Int)->Bool{
+        return root(x:x) == root(x:y)
+    }
+}

--- a/Sources/AtCoderSupport/UnionFind.swift
+++ b/Sources/AtCoderSupport/UnionFind.swift
@@ -1,39 +1,35 @@
 struct UnionFind {
-    var par:[Int]
-    var rank:[Int]
-    var n:Int
-    init(n:Int){
-        self.n = n
-        self.par = Array(repeating:0,count:n)
-        self.rank = Array(repeating:0,count:n)
-        for i in 0..<n{
-            par[i] = i
-        }
+    private var parents: [Int]
+    private var ranks: [Int]
+    private let max: Int
+
+    init(max: Int) {
+        precondition(max >= 0)
+        self.max = max
+        self.parents = Array(0 ..< max)
+        self.ranks = Array(repeating: 0, count: max)
     }
-    mutating func root(x:Int) -> Int {
-        if par[x] == x{
-            return x
-        }
-        else{
-            return root(x:par[x])
-        }
+
+    func root(of i: Int) -> Int {
+        if parents[i] == i { return i }
+        return root(of: parents[i])
     }
-    mutating func unite (x:Int,y:Int){
-        let x = root(x:x)
-        let y = root(x:y)
-        if x == y{
-            return
-        }
-        if rank[x] < rank[y]{
-            par[x] = y
+
+    mutating func unite(_ x: Int, _ y: Int) {
+        let x = root(of: x)
+        let y = root(of: y)
+        if x == y { return }
+        if ranks[x] < ranks[y] {
+            parents[x] = y
         } else {
-            par[y] = x
-            if rank[x] == rank[y]{
-                rank[x] += 1
+            parents[y] = x
+            if ranks[x] == ranks[y] {
+                ranks[x] += 1
             }
         }
     }
-    mutating func same(x:Int,y:Int)->Bool{
-        return root(x:x) == root(x:y)
+
+    func areSame(_ x: Int, _ y: Int) -> Bool {
+        root(of:x) == root(of:y)
     }
 }

--- a/Sources/AtCoderSupport/UnionFind.swift
+++ b/Sources/AtCoderSupport/UnionFind.swift
@@ -2,10 +2,10 @@ struct UnionFind {
     private var parents: [Int]
     private var ranks: [Int]
 
-    init(max: Int) {
-        precondition(max >= 0)
-        self.parents = Array(0 ..< max)
-        self.ranks = Array(repeating: 0, count: max)
+    init(count: Int) {
+        precondition(count >= 0)
+        self.parents = Array(0 ..< count)
+        self.ranks = Array(repeating: 0, count: count)
     }
 
     func root(of i: Int) -> Int {

--- a/Sources/AtCoderSupport/UnionFind.swift
+++ b/Sources/AtCoderSupport/UnionFind.swift
@@ -1,11 +1,9 @@
 struct UnionFind {
     private var parents: [Int]
     private var ranks: [Int]
-    private let max: Int
 
     init(max: Int) {
         precondition(max >= 0)
-        self.max = max
         self.parents = Array(0 ..< max)
         self.ranks = Array(repeating: 0, count: max)
     }

--- a/Tests/AtCoderSupportTests/UnionFindTests.swift
+++ b/Tests/AtCoderSupportTests/UnionFindTests.swift
@@ -1,0 +1,123 @@
+import XCTest
+@testable import AtCoderSupport
+
+final class UnionFindTests: XCTestCase {
+    func testUnionFind() {
+        do {
+            let n = 10
+            var unionFind: UnionFind = .init(n: n)
+            
+            for i in 0 ..< n { // root
+                XCTAssertEqual(unionFind.root(x: i), i)
+            }
+            for i in 0 ..< n { // areSame
+                for j in 0 ..< n {
+                    if i == j {
+                        XCTAssertTrue(unionFind.same(x: i, y: j))
+                    } else {
+                        XCTAssertFalse(unionFind.same(x: i, y: j))
+                    }
+                }
+            }
+
+            unionFind.unite(x: 2, y: 3)
+            XCTAssertEqual(unionFind.root(x: 2), unionFind.root(x: 3))
+            do {
+                let groups: [Set<Int>] = [[0], [1], [4], [5], [6], [7], [8], [9], [2, 3]]
+                for i in 0 ..< n { // root
+                    if groups.first(where: { $0.contains(i) })!.count > 1 { continue }
+                    XCTAssertEqual(unionFind.root(x: i), i)
+                }
+                for i in 0 ..< n { // areSame
+                    for j in 0 ..< n {
+                        if groups.reduce(false, { $0 || $1.contains(i) && $1.contains(j)}) {
+                            XCTAssertTrue(unionFind.same(x: i, y: j))
+                        } else {
+                            XCTAssertFalse(unionFind.same(x: i, y: j))
+                        }
+                    }
+                }
+            }
+            
+            unionFind.unite(x: 5, y: 7)
+            XCTAssertEqual(unionFind.root(x: 5), unionFind.root(x: 7))
+            XCTAssertEqual(unionFind.root(x: 2), unionFind.root(x: 3))
+            do {
+                let groups: [Set<Int>] = [[0], [1], [4], [6], [8], [9], [2, 3], [5, 7]]
+                for i in 0 ..< n { // root
+                    if groups.first(where: { $0.contains(i) })!.count > 1 { continue }
+                    XCTAssertEqual(unionFind.root(x: i), i)
+                }
+                for i in 0 ..< n { // areSame
+                    for j in 0 ..< n {
+                        if groups.reduce(false, { $0 || $1.contains(i) && $1.contains(j)}) {
+                            XCTAssertTrue(unionFind.same(x: i, y: j))
+                        } else {
+                            XCTAssertFalse(unionFind.same(x: i, y: j))
+                        }
+                    }
+                }
+            }
+
+            unionFind.unite(x: 1, y: 2)
+            XCTAssertEqual(unionFind.root(x: 1), unionFind.root(x: 2))
+            XCTAssertEqual(unionFind.root(x: 1), unionFind.root(x: 3))
+            XCTAssertEqual(unionFind.root(x: 2), unionFind.root(x: 3))
+            XCTAssertEqual(unionFind.root(x: 5), unionFind.root(x: 7))
+            do {
+                let groups: [Set<Int>] = [[0], [4], [6], [8], [9], [1, 2, 3], [5, 7]]
+                for i in 0 ..< n { // root
+                    if groups.first(where: { $0.contains(i) })!.count > 1 { continue }
+                    XCTAssertEqual(unionFind.root(x: i), i)
+                }
+                for i in 0 ..< n { // areSame
+                    for j in 0 ..< n {
+                        if groups.reduce(false, { $0 || $1.contains(i) && $1.contains(j)}) {
+                            XCTAssertTrue(unionFind.same(x: i, y: j))
+                        } else {
+                            XCTAssertFalse(unionFind.same(x: i, y: j))
+                        }
+                    }
+                }
+            }
+            
+            unionFind.unite(x: 3, y: 7)
+            XCTAssertEqual(unionFind.root(x: 1), unionFind.root(x: 2))
+            XCTAssertEqual(unionFind.root(x: 1), unionFind.root(x: 3))
+            XCTAssertEqual(unionFind.root(x: 1), unionFind.root(x: 5))
+            XCTAssertEqual(unionFind.root(x: 1), unionFind.root(x: 7))
+            XCTAssertEqual(unionFind.root(x: 2), unionFind.root(x: 1))
+            XCTAssertEqual(unionFind.root(x: 2), unionFind.root(x: 3))
+            XCTAssertEqual(unionFind.root(x: 2), unionFind.root(x: 5))
+            XCTAssertEqual(unionFind.root(x: 2), unionFind.root(x: 7))
+            XCTAssertEqual(unionFind.root(x: 3), unionFind.root(x: 1))
+            XCTAssertEqual(unionFind.root(x: 3), unionFind.root(x: 2))
+            XCTAssertEqual(unionFind.root(x: 3), unionFind.root(x: 5))
+            XCTAssertEqual(unionFind.root(x: 3), unionFind.root(x: 7))
+            XCTAssertEqual(unionFind.root(x: 5), unionFind.root(x: 1))
+            XCTAssertEqual(unionFind.root(x: 5), unionFind.root(x: 2))
+            XCTAssertEqual(unionFind.root(x: 5), unionFind.root(x: 3))
+            XCTAssertEqual(unionFind.root(x: 5), unionFind.root(x: 7))
+            XCTAssertEqual(unionFind.root(x: 7), unionFind.root(x: 1))
+            XCTAssertEqual(unionFind.root(x: 7), unionFind.root(x: 2))
+            XCTAssertEqual(unionFind.root(x: 7), unionFind.root(x: 3))
+            XCTAssertEqual(unionFind.root(x: 7), unionFind.root(x: 5))
+            do {
+                let groups: [Set<Int>] = [[0], [4], [6], [8], [9], [1, 2, 3, 5, 7]]
+                for i in 0 ..< n { // root
+                    if groups.first(where: { $0.contains(i) })!.count > 1 { continue }
+                    XCTAssertEqual(unionFind.root(x: i), i)
+                }
+                for i in 0 ..< n { // areSame
+                    for j in 0 ..< n {
+                        if groups.reduce(false, { $0 || $1.contains(i) && $1.contains(j)}) {
+                            XCTAssertTrue(unionFind.same(x: i, y: j))
+                        } else {
+                            XCTAssertFalse(unionFind.same(x: i, y: j))
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Tests/AtCoderSupportTests/UnionFindTests.swift
+++ b/Tests/AtCoderSupportTests/UnionFindTests.swift
@@ -13,9 +13,9 @@ final class UnionFindTests: XCTestCase {
             for i in 0 ..< n { // areSame
                 for j in 0 ..< n {
                     if i == j {
-                        XCTAssertTrue(unionFind.areSame(i, j))
+                        XCTAssertTrue(unionFind.areInSameSet(i, j))
                     } else {
-                        XCTAssertFalse(unionFind.areSame(i, j))
+                        XCTAssertFalse(unionFind.areInSameSet(i, j))
                     }
                 }
             }
@@ -31,9 +31,9 @@ final class UnionFindTests: XCTestCase {
                 for i in 0 ..< n { // areSame
                     for j in 0 ..< n {
                         if groups.reduce(false, { $0 || $1.contains(i) && $1.contains(j)}) {
-                            XCTAssertTrue(unionFind.areSame(i, j))
+                            XCTAssertTrue(unionFind.areInSameSet(i, j))
                         } else {
-                            XCTAssertFalse(unionFind.areSame(i, j))
+                            XCTAssertFalse(unionFind.areInSameSet(i, j))
                         }
                     }
                 }
@@ -51,9 +51,9 @@ final class UnionFindTests: XCTestCase {
                 for i in 0 ..< n { // areSame
                     for j in 0 ..< n {
                         if groups.reduce(false, { $0 || $1.contains(i) && $1.contains(j)}) {
-                            XCTAssertTrue(unionFind.areSame(i, j))
+                            XCTAssertTrue(unionFind.areInSameSet(i, j))
                         } else {
-                            XCTAssertFalse(unionFind.areSame(i, j))
+                            XCTAssertFalse(unionFind.areInSameSet(i, j))
                         }
                     }
                 }
@@ -73,9 +73,9 @@ final class UnionFindTests: XCTestCase {
                 for i in 0 ..< n { // areSame
                     for j in 0 ..< n {
                         if groups.reduce(false, { $0 || $1.contains(i) && $1.contains(j)}) {
-                            XCTAssertTrue(unionFind.areSame(i, j))
+                            XCTAssertTrue(unionFind.areInSameSet(i, j))
                         } else {
-                            XCTAssertFalse(unionFind.areSame(i, j))
+                            XCTAssertFalse(unionFind.areInSameSet(i, j))
                         }
                     }
                 }
@@ -111,9 +111,9 @@ final class UnionFindTests: XCTestCase {
                 for i in 0 ..< n { // areSame
                     for j in 0 ..< n {
                         if groups.reduce(false, { $0 || $1.contains(i) && $1.contains(j)}) {
-                            XCTAssertTrue(unionFind.areSame(i, j))
+                            XCTAssertTrue(unionFind.areInSameSet(i, j))
                         } else {
-                            XCTAssertFalse(unionFind.areSame(i, j))
+                            XCTAssertFalse(unionFind.areInSameSet(i, j))
                         }
                     }
                 }
@@ -129,7 +129,7 @@ final class UnionFindTests: XCTestCase {
             for i in 1 ..< n {
                 unionFind.unite(i - 1, i)
             }
-            XCTAssertTrue(unionFind.areSame(0, n - 1))
+            XCTAssertTrue(unionFind.areInSameSet(0, n - 1))
         }
     }
     #endif

--- a/Tests/AtCoderSupportTests/UnionFindTests.swift
+++ b/Tests/AtCoderSupportTests/UnionFindTests.swift
@@ -5,7 +5,7 @@ final class UnionFindTests: XCTestCase {
     func testUnionFind() {
         do {
             let n = 10
-            var unionFind: UnionFind = .init(max: n)
+            var unionFind: UnionFind = .init(count: n)
             
             for i in 0 ..< n { // root
                 XCTAssertEqual(unionFind.root(of: i), i)
@@ -125,7 +125,7 @@ final class UnionFindTests: XCTestCase {
     func testUnionFindPerformance() {
         let n = 10_000_000
         measure {
-            var unionFind: UnionFind = .init(max: n)
+            var unionFind: UnionFind = .init(count: n)
             for i in 1 ..< n {
                 unionFind.unite(i - 1, i)
             }

--- a/Tests/AtCoderSupportTests/UnionFindTests.swift
+++ b/Tests/AtCoderSupportTests/UnionFindTests.swift
@@ -120,4 +120,17 @@ final class UnionFindTests: XCTestCase {
             }
         }
     }
+    
+    #if !DEBUG
+    func testUnionFindPerformance() {
+        let n = 10_000_000
+        measure {
+            var unionFind: UnionFind = .init(max: n)
+            for i in 1 ..< n {
+                unionFind.unite(i - 1, i)
+            }
+            XCTAssertTrue(unionFind.areSame(0, n - 1))
+        }
+    }
+    #endif
 }

--- a/Tests/AtCoderSupportTests/UnionFindTests.swift
+++ b/Tests/AtCoderSupportTests/UnionFindTests.swift
@@ -5,115 +5,115 @@ final class UnionFindTests: XCTestCase {
     func testUnionFind() {
         do {
             let n = 10
-            var unionFind: UnionFind = .init(n: n)
+            var unionFind: UnionFind = .init(max: n)
             
             for i in 0 ..< n { // root
-                XCTAssertEqual(unionFind.root(x: i), i)
+                XCTAssertEqual(unionFind.root(of: i), i)
             }
             for i in 0 ..< n { // areSame
                 for j in 0 ..< n {
                     if i == j {
-                        XCTAssertTrue(unionFind.same(x: i, y: j))
+                        XCTAssertTrue(unionFind.areSame(i, j))
                     } else {
-                        XCTAssertFalse(unionFind.same(x: i, y: j))
+                        XCTAssertFalse(unionFind.areSame(i, j))
                     }
                 }
             }
 
-            unionFind.unite(x: 2, y: 3)
-            XCTAssertEqual(unionFind.root(x: 2), unionFind.root(x: 3))
+            unionFind.unite(2, 3)
+            XCTAssertEqual(unionFind.root(of: 2), unionFind.root(of: 3))
             do {
                 let groups: [Set<Int>] = [[0], [1], [4], [5], [6], [7], [8], [9], [2, 3]]
                 for i in 0 ..< n { // root
                     if groups.first(where: { $0.contains(i) })!.count > 1 { continue }
-                    XCTAssertEqual(unionFind.root(x: i), i)
+                    XCTAssertEqual(unionFind.root(of: i), i)
                 }
                 for i in 0 ..< n { // areSame
                     for j in 0 ..< n {
                         if groups.reduce(false, { $0 || $1.contains(i) && $1.contains(j)}) {
-                            XCTAssertTrue(unionFind.same(x: i, y: j))
+                            XCTAssertTrue(unionFind.areSame(i, j))
                         } else {
-                            XCTAssertFalse(unionFind.same(x: i, y: j))
+                            XCTAssertFalse(unionFind.areSame(i, j))
                         }
                     }
                 }
             }
             
-            unionFind.unite(x: 5, y: 7)
-            XCTAssertEqual(unionFind.root(x: 5), unionFind.root(x: 7))
-            XCTAssertEqual(unionFind.root(x: 2), unionFind.root(x: 3))
+            unionFind.unite(5, 7)
+            XCTAssertEqual(unionFind.root(of: 5), unionFind.root(of: 7))
+            XCTAssertEqual(unionFind.root(of: 2), unionFind.root(of: 3))
             do {
                 let groups: [Set<Int>] = [[0], [1], [4], [6], [8], [9], [2, 3], [5, 7]]
                 for i in 0 ..< n { // root
                     if groups.first(where: { $0.contains(i) })!.count > 1 { continue }
-                    XCTAssertEqual(unionFind.root(x: i), i)
+                    XCTAssertEqual(unionFind.root(of: i), i)
                 }
                 for i in 0 ..< n { // areSame
                     for j in 0 ..< n {
                         if groups.reduce(false, { $0 || $1.contains(i) && $1.contains(j)}) {
-                            XCTAssertTrue(unionFind.same(x: i, y: j))
+                            XCTAssertTrue(unionFind.areSame(i, j))
                         } else {
-                            XCTAssertFalse(unionFind.same(x: i, y: j))
+                            XCTAssertFalse(unionFind.areSame(i, j))
                         }
                     }
                 }
             }
 
-            unionFind.unite(x: 1, y: 2)
-            XCTAssertEqual(unionFind.root(x: 1), unionFind.root(x: 2))
-            XCTAssertEqual(unionFind.root(x: 1), unionFind.root(x: 3))
-            XCTAssertEqual(unionFind.root(x: 2), unionFind.root(x: 3))
-            XCTAssertEqual(unionFind.root(x: 5), unionFind.root(x: 7))
+            unionFind.unite(1, 2)
+            XCTAssertEqual(unionFind.root(of: 1), unionFind.root(of: 2))
+            XCTAssertEqual(unionFind.root(of: 1), unionFind.root(of: 3))
+            XCTAssertEqual(unionFind.root(of: 2), unionFind.root(of: 3))
+            XCTAssertEqual(unionFind.root(of: 5), unionFind.root(of: 7))
             do {
                 let groups: [Set<Int>] = [[0], [4], [6], [8], [9], [1, 2, 3], [5, 7]]
                 for i in 0 ..< n { // root
                     if groups.first(where: { $0.contains(i) })!.count > 1 { continue }
-                    XCTAssertEqual(unionFind.root(x: i), i)
+                    XCTAssertEqual(unionFind.root(of: i), i)
                 }
                 for i in 0 ..< n { // areSame
                     for j in 0 ..< n {
                         if groups.reduce(false, { $0 || $1.contains(i) && $1.contains(j)}) {
-                            XCTAssertTrue(unionFind.same(x: i, y: j))
+                            XCTAssertTrue(unionFind.areSame(i, j))
                         } else {
-                            XCTAssertFalse(unionFind.same(x: i, y: j))
+                            XCTAssertFalse(unionFind.areSame(i, j))
                         }
                     }
                 }
             }
             
-            unionFind.unite(x: 3, y: 7)
-            XCTAssertEqual(unionFind.root(x: 1), unionFind.root(x: 2))
-            XCTAssertEqual(unionFind.root(x: 1), unionFind.root(x: 3))
-            XCTAssertEqual(unionFind.root(x: 1), unionFind.root(x: 5))
-            XCTAssertEqual(unionFind.root(x: 1), unionFind.root(x: 7))
-            XCTAssertEqual(unionFind.root(x: 2), unionFind.root(x: 1))
-            XCTAssertEqual(unionFind.root(x: 2), unionFind.root(x: 3))
-            XCTAssertEqual(unionFind.root(x: 2), unionFind.root(x: 5))
-            XCTAssertEqual(unionFind.root(x: 2), unionFind.root(x: 7))
-            XCTAssertEqual(unionFind.root(x: 3), unionFind.root(x: 1))
-            XCTAssertEqual(unionFind.root(x: 3), unionFind.root(x: 2))
-            XCTAssertEqual(unionFind.root(x: 3), unionFind.root(x: 5))
-            XCTAssertEqual(unionFind.root(x: 3), unionFind.root(x: 7))
-            XCTAssertEqual(unionFind.root(x: 5), unionFind.root(x: 1))
-            XCTAssertEqual(unionFind.root(x: 5), unionFind.root(x: 2))
-            XCTAssertEqual(unionFind.root(x: 5), unionFind.root(x: 3))
-            XCTAssertEqual(unionFind.root(x: 5), unionFind.root(x: 7))
-            XCTAssertEqual(unionFind.root(x: 7), unionFind.root(x: 1))
-            XCTAssertEqual(unionFind.root(x: 7), unionFind.root(x: 2))
-            XCTAssertEqual(unionFind.root(x: 7), unionFind.root(x: 3))
-            XCTAssertEqual(unionFind.root(x: 7), unionFind.root(x: 5))
+            unionFind.unite(3, 7)
+            XCTAssertEqual(unionFind.root(of: 1), unionFind.root(of: 2))
+            XCTAssertEqual(unionFind.root(of: 1), unionFind.root(of: 3))
+            XCTAssertEqual(unionFind.root(of: 1), unionFind.root(of: 5))
+            XCTAssertEqual(unionFind.root(of: 1), unionFind.root(of: 7))
+            XCTAssertEqual(unionFind.root(of: 2), unionFind.root(of: 1))
+            XCTAssertEqual(unionFind.root(of: 2), unionFind.root(of: 3))
+            XCTAssertEqual(unionFind.root(of: 2), unionFind.root(of: 5))
+            XCTAssertEqual(unionFind.root(of: 2), unionFind.root(of: 7))
+            XCTAssertEqual(unionFind.root(of: 3), unionFind.root(of: 1))
+            XCTAssertEqual(unionFind.root(of: 3), unionFind.root(of: 2))
+            XCTAssertEqual(unionFind.root(of: 3), unionFind.root(of: 5))
+            XCTAssertEqual(unionFind.root(of: 3), unionFind.root(of: 7))
+            XCTAssertEqual(unionFind.root(of: 5), unionFind.root(of: 1))
+            XCTAssertEqual(unionFind.root(of: 5), unionFind.root(of: 2))
+            XCTAssertEqual(unionFind.root(of: 5), unionFind.root(of: 3))
+            XCTAssertEqual(unionFind.root(of: 5), unionFind.root(of: 7))
+            XCTAssertEqual(unionFind.root(of: 7), unionFind.root(of: 1))
+            XCTAssertEqual(unionFind.root(of: 7), unionFind.root(of: 2))
+            XCTAssertEqual(unionFind.root(of: 7), unionFind.root(of: 3))
+            XCTAssertEqual(unionFind.root(of: 7), unionFind.root(of: 5))
             do {
                 let groups: [Set<Int>] = [[0], [4], [6], [8], [9], [1, 2, 3, 5, 7]]
                 for i in 0 ..< n { // root
                     if groups.first(where: { $0.contains(i) })!.count > 1 { continue }
-                    XCTAssertEqual(unionFind.root(x: i), i)
+                    XCTAssertEqual(unionFind.root(of: i), i)
                 }
                 for i in 0 ..< n { // areSame
                     for j in 0 ..< n {
                         if groups.reduce(false, { $0 || $1.contains(i) && $1.contains(j)}) {
-                            XCTAssertTrue(unionFind.same(x: i, y: j))
+                            XCTAssertTrue(unionFind.areSame(i, j))
                         } else {
-                            XCTAssertFalse(unionFind.same(x: i, y: j))
+                            XCTAssertFalse(unionFind.areSame(i, j))
                         }
                     }
                 }


### PR DESCRIPTION
#5 から引き継ぎ。

- #5 に #4 コミットが混ざってしまっていたので、 `UnionFind` に関するものだけ抽出して rebase しました。
- テストケースを追加しました。
- コードをリファクタリングしました（大筋は変わっていません）。
- 再帰で書かれていた `root` をループで書き直したました。