### PR TITLE
`dfs` のパフォーマンス改善

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Swift Package 形式になっていますが、 AtCoder で利用する際には
 |:--|:--|:--|
 | 順列 | `permutations()` | [ABC 145 C - Average Length](https://atcoder.jp/contests/abc145/submissions/17547859) |
 | 二分探索 | `values(_:_:)` | [ABC 077 C - Snuke Festival](https://atcoder.jp/contests/abc077/submissions/17547635) |
-| 深さ優先探索 | `dfs(edges:startedAt:_:)` | [ABC 138 D - Ki](https://atcoder.jp/contests/abc138/submissions/17546144) |
+| 深さ優先探索 | `dfs(edges:startedAt:_:)` | [ABC 138 D - Ki](https://atcoder.jp/contests/abc138/submissions/17661705) |
 | 素数判定 | `isPrime` | [ABC 149 C - Next Prime](https://atcoder.jp/contests/abc149/submissions/17548101) |
 | ダイクストラ法 | `dijkstra(graph:startedAt:)` | [ABC 035 D - トレジャーハント](https://atcoder.jp/contests/abc035/submissions/17662367) |
 | 巡回セールスマン問題 | `tsp(distances:startedAt:)` | [ABC 180 E - Traveling Salesman among Aerial Cities](https://atcoder.jp/contests/abc180/submissions/17561600) |

--- a/Sources/AtCoderSupport/DFS.swift
+++ b/Sources/AtCoderSupport/DFS.swift
@@ -1,11 +1,11 @@
 func dfs(edges: [[Int]], startedAt start: Int, _ body: (Int) -> Void) {
     precondition(edges.indices.contains(start), "`start` index is out of bounds: \(start)")
-    var visited: Set<Int> = []
+    var isVisited: [Bool] = .init(repeating: false, count: edges.count)
     var destinations: [Int] = [start]
     while let current = destinations.popLast() {
-        if visited.contains(current) { continue }
+        if isVisited[current] { continue }
         body(current)
-        visited.insert(current)
+        isVisited[current] = true
         for destination in edges[current].reversed() {
             destinations.append(destination)
         }
@@ -14,12 +14,12 @@ func dfs(edges: [[Int]], startedAt start: Int, _ body: (Int) -> Void) {
 
 func dfs(edges: [[Int]], startedAt start: Int, _ body: (_ current: Int, _ prev: Int?) -> Void) {
     precondition(edges.indices.contains(start), "`start` index is out of bounds: \(start)")
-    var visited: Set<Int> = []
+    var isVisited: [Bool] = .init(repeating: false, count: edges.count)
     var destinations: [(current: Int, prev: Int?)] = [(start, nil)]
     while let (current, prev) = destinations.popLast() {
-        if visited.contains(current) { continue }
+        if isVisited[current] { continue }
         body(current, prev)
-        visited.insert(current)
+        isVisited[current] = true
         for destination in edges[current].reversed() {
             destinations.append((destination, current))
         }
@@ -28,12 +28,12 @@ func dfs(edges: [[Int]], startedAt start: Int, _ body: (_ current: Int, _ prev: 
 
 func dfs(edges: [[Int]], startedAt start: Int, _ body: (_ current: Int, _ prev: Int?, _ depth: Int) -> Void) {
     precondition(edges.indices.contains(start), "`start` index is out of bounds: \(start)")
-    var visited: Set<Int> = []
+    var isVisited: [Bool] = .init(repeating: false, count: edges.count)
     var destinations: [(current: Int, prev: Int?, depth: Int)] = [(start, nil, 0)]
     while let (current, prev, depth) = destinations.popLast() {
-        if visited.contains(current) { continue }
+        if isVisited[current] { continue }
         body(current, prev, depth)
-        visited.insert(current)
+        isVisited[current] = true
         for destination in edges[current].reversed() {
             destinations.append((destination, current, depth + 1))
         }

--- a/Tests/AtCoderSupportTests/DFSTests.swift
+++ b/Tests/AtCoderSupportTests/DFSTests.swift
@@ -289,4 +289,66 @@ final class DFSTests: XCTestCase {
             }
         }
     }
+    
+    func testDFSPerformance() {
+        let n = (1 << 20) - 1
+        let edges: [[Int]] = (1 ... n).map {
+            let left = $0 << 1
+            let right = left + 1
+            if right <= n {
+                return [left - 1, right - 1]
+            } else if left <= n {
+                return [left - 1]
+            } else {
+                return []
+            }
+        }
+        measure {
+            var count = 0
+            dfs(edges: edges, startedAt: 0) { _ in count += 1 }
+            XCTAssertEqual(count, edges.count)
+        }
+    }
+    
+    #if !DEBUG
+    func testDFSWithPrevPerformance() {
+        let n = (1 << 20) - 1
+        let edges: [[Int]] = (1 ... n).map {
+            let left = $0 << 1
+            let right = left + 1
+            if right <= n {
+                return [left - 1, right - 1]
+            } else if left <= n {
+                return [left - 1]
+            } else {
+                return []
+            }
+        }
+        measure {
+            var count = 0
+            dfs(edges: edges, startedAt: 0) { _, _ in count += 1 }
+            XCTAssertEqual(count, edges.count)
+        }
+    }
+    
+    func testDFSWithPrevDepthPerformance() {
+        let n = (1 << 20) - 1
+        let edges: [[Int]] = (1 ... n).map {
+            let left = $0 << 1
+            let right = left + 1
+            if right <= n {
+                return [left - 1, right - 1]
+            } else if left <= n {
+                return [left - 1]
+            } else {
+                return []
+            }
+        }
+        measure {
+            var count = 0
+            dfs(edges: edges, startedAt: 0) { _, _, _ in count += 1 }
+            XCTAssertEqual(count, edges.count)
+        }
+    }
+    #endif
 }


### PR DESCRIPTION
訪問済みノードを `Set<Int>` で管理していたのを `[Bool]` に置き換えました。これにより `DFSTests` のパフォーマンステスト上は 5 倍ほど高速になりました。しかし、利用例である "ABC 138 D - Ki" ではそこはボトルネックでないらしく、改善は見られませんでした（むしろ誤差の範囲で遅くなりました）。