### PR TITLE
`bfs` のパフォーマンス改善

### DIFF
--- a/Sources/AtCoderSupport/BFS.swift
+++ b/Sources/AtCoderSupport/BFS.swift
@@ -1,9 +1,12 @@
 func bfs(edges: [[Int]], startedAt start: Int, _ operation: (Int) -> Void) {
     precondition(edges.indices.contains(start), "`start` index is out of bounds: \(start)")
     var isVisited: [Bool] = .init(repeating: false, count: edges.count)
-    var destinations: ArraySlice<Int> = [start]
+    var destinations: [Int] = [start]
     destinations.reserveCapacity(edges.count)
-    while let current = destinations.popFirst() {
+    var i = 0
+    while i < destinations.count {
+        defer { i += 1 }
+        let current = destinations[i]
         if isVisited[current] { continue }
         operation(current)
         isVisited[current] = true
@@ -16,35 +19,35 @@ func bfs(edges: [[Int]], startedAt start: Int, _ operation: (Int) -> Void) {
 func bfs(edges: [[Int]], startedAt start: Int, _ operation: (_ current: Int, _ prev: Int?) -> Void) {
     precondition(edges.indices.contains(start), "`start` index is out of bounds: \(start)")
     var isVisited: [Bool] = .init(repeating: false, count: edges.count)
-    var nexts: [(current: Int, prev: Int?)] = [(start, nil)]
-    while !nexts.isEmpty {
-        var destinations: [(current: Int, prev: Int?)] = []
-        for (current, prev) in nexts {
-            if isVisited[current] { continue }
-            operation(current, prev)
-            isVisited[current] = true
-            for destination in edges[current] {
-                destinations.append((destination, current))
-            }
+    var destinations: [(current: Int, prev: Int?)] = [(start, nil)]
+    destinations.reserveCapacity(edges.count)
+    var i = 0
+    while i < destinations.count {
+        defer { i += 1 }
+        let (current, prev) = destinations[i]
+        if isVisited[current] { continue }
+        operation(current, prev)
+        isVisited[current] = true
+        for destination in edges[current] {
+            destinations.append((destination, current))
         }
-        nexts = destinations
     }
 }
 
 func bfs(edges: [[Int]], startedAt start: Int, _ operation: (_ current: Int, _ prev: Int?, _ depth: Int) -> Void) {
     precondition(edges.indices.contains(start), "`start` index is out of bounds: \(start)")
     var isVisited: [Bool] = .init(repeating: false, count: edges.count)
-    var nexts: [(current: Int, prev: Int?, depth: Int)] = [(start, nil, 0)]
-    while !nexts.isEmpty {
-        var destinations: [(current: Int, prev: Int?, depth: Int)] = []
-        for (current, prev, depth) in nexts {
-            if isVisited[current] { continue }
-            operation(current, prev, depth)
-            isVisited[current] = true
-            for destination in edges[current] {
-                destinations.append((destination, current, depth + 1))
-            }
+    var destinations: [(current: Int, prev: Int?, depth: Int)] = [(start, nil, 0)]
+    destinations.reserveCapacity(edges.count)
+    var i = 0
+    while i < destinations.count {
+        defer { i += 1 }
+        let (current, prev, depth) = destinations[i]
+        if isVisited[current] { continue }
+        operation(current, prev, depth)
+        isVisited[current] = true
+        for destination in edges[current] {
+            destinations.append((destination, current, depth + 1))
         }
-        nexts = destinations
     }
 }

--- a/Sources/AtCoderSupport/BFS.swift
+++ b/Sources/AtCoderSupport/BFS.swift
@@ -1,18 +1,15 @@
 func bfs(edges: [[Int]], startedAt start: Int, _ operation: (Int) -> Void) {
     precondition(edges.indices.contains(start), "`start` index is out of bounds: \(start)")
     var isVisited: [Bool] = .init(repeating: false, count: edges.count)
-    var nexts: [Int] = [start]
-    while !nexts.isEmpty {
-        var destinations: [Int] = []
-        for current in nexts {
-            if isVisited[current] { continue }
-            operation(current)
-            isVisited[current] = true
-            for destination in edges[current] {
-                destinations.append(destination)
-            }
+    var destinations: ArraySlice<Int> = [start]
+    destinations.reserveCapacity(edges.count)
+    while let current = destinations.popFirst() {
+        if isVisited[current] { continue }
+        operation(current)
+        isVisited[current] = true
+        for destination in edges[current] {
+            destinations.append(destination)
         }
-        nexts = destinations
     }
 }
 

--- a/Sources/AtCoderSupport/BFS.swift
+++ b/Sources/AtCoderSupport/BFS.swift
@@ -1,13 +1,13 @@
 func bfs(edges: [[Int]], startedAt start: Int, _ operation: (Int) -> Void) {
     precondition(edges.indices.contains(start), "`start` index is out of bounds: \(start)")
-    var visited: Set<Int> = []
+    var isVisited: [Bool] = .init(repeating: false, count: edges.count)
     var nexts: [Int] = [start]
     while !nexts.isEmpty {
         var destinations: [Int] = []
         for current in nexts {
-            if visited.contains(current) { continue }
+            if isVisited[current] { continue }
             operation(current)
-            visited.insert(current)
+            isVisited[current] = true
             for destination in edges[current] {
                 destinations.append(destination)
             }
@@ -18,14 +18,14 @@ func bfs(edges: [[Int]], startedAt start: Int, _ operation: (Int) -> Void) {
 
 func bfs(edges: [[Int]], startedAt start: Int, _ operation: (_ current: Int, _ prev: Int?) -> Void) {
     precondition(edges.indices.contains(start), "`start` index is out of bounds: \(start)")
-    var visited: Set<Int> = []
+    var isVisited: [Bool] = .init(repeating: false, count: edges.count)
     var nexts: [(current: Int, prev: Int?)] = [(start, nil)]
     while !nexts.isEmpty {
         var destinations: [(current: Int, prev: Int?)] = []
         for (current, prev) in nexts {
-            if visited.contains(current) { continue }
+            if isVisited[current] { continue }
             operation(current, prev)
-            visited.insert(current)
+            isVisited[current] = true
             for destination in edges[current] {
                 destinations.append((destination, current))
             }
@@ -36,14 +36,14 @@ func bfs(edges: [[Int]], startedAt start: Int, _ operation: (_ current: Int, _ p
 
 func bfs(edges: [[Int]], startedAt start: Int, _ operation: (_ current: Int, _ prev: Int?, _ depth: Int) -> Void) {
     precondition(edges.indices.contains(start), "`start` index is out of bounds: \(start)")
-    var visited: Set<Int> = []
+    var isVisited: [Bool] = .init(repeating: false, count: edges.count)
     var nexts: [(current: Int, prev: Int?, depth: Int)] = [(start, nil, 0)]
     while !nexts.isEmpty {
         var destinations: [(current: Int, prev: Int?, depth: Int)] = []
         for (current, prev, depth) in nexts {
-            if visited.contains(current) { continue }
+            if isVisited[current] { continue }
             operation(current, prev, depth)
-            visited.insert(current)
+            isVisited[current] = true
             for destination in edges[current] {
                 destinations.append((destination, current, depth + 1))
             }

--- a/Tests/AtCoderSupportTests/BFSTests.swift
+++ b/Tests/AtCoderSupportTests/BFSTests.swift
@@ -289,4 +289,66 @@ final class BFSTests: XCTestCase {
             }
         }
     }
+
+    #if !DEBUG
+    func testBFSPerformance() {
+        let n = (1 << 20) - 1
+        let edges: [[Int]] = (1 ... n).map {
+            let left = $0 << 1
+            let right = left + 1
+            if right <= n {
+                return [left - 1, right - 1]
+            } else if left <= n {
+                return [left - 1]
+            } else {
+                return []
+            }
+        }
+        measure {
+            var count = 0
+            bfs(edges: edges, startedAt: 0) { _ in count += 1 }
+            XCTAssertEqual(count, edges.count)
+        }
+    }
+    
+    func testBFSWithPrevPerformance() {
+        let n = (1 << 20) - 1
+        let edges: [[Int]] = (1 ... n).map {
+            let left = $0 << 1
+            let right = left + 1
+            if right <= n {
+                return [left - 1, right - 1]
+            } else if left <= n {
+                return [left - 1]
+            } else {
+                return []
+            }
+        }
+        measure {
+            var count = 0
+            bfs(edges: edges, startedAt: 0) { _, _ in count += 1 }
+            XCTAssertEqual(count, edges.count)
+        }
+    }
+    
+    func testBFSWithPrevDepthPerformance() {
+        let n = (1 << 20) - 1
+        let edges: [[Int]] = (1 ... n).map {
+            let left = $0 << 1
+            let right = left + 1
+            if right <= n {
+                return [left - 1, right - 1]
+            } else if left <= n {
+                return [left - 1]
+            } else {
+                return []
+            }
+        }
+        measure {
+            var count = 0
+            bfs(edges: edges, startedAt: 0) { _, _, _ in count += 1 }
+            XCTAssertEqual(count, edges.count)
+        }
+    }
+    #endif
 }


### PR DESCRIPTION
訪問済みノードを `Set<Int>` で管理していたのを `[Bool]` に置き換えました。これにより `BFSTests` のパフォーマンステスト上は 5 倍ほど高速になりました。

よりシンプルな実装として、キューを `ArraySlice` で表す次のような実装を検討しました。

```swift
func bfs(edges: [[Int]], startedAt start: Int, _ operation: (Int) -> Void) {
    precondition(edges.indices.contains(start), "`start` index is out of bounds: \(start)")
    var isVisited: [Bool] = .init(repeating: false, count: edges.count)
    var destinations: ArraySlice<Int> = [start]
    destinations.reserveCapacity(edges.count)
    while let current = destinations.popFirst() {
        if isVisited[current] { continue }
        operation(current)
        isVisited[current] = true
        for destination in edges[current] {
            destinations.append(destination)
        }
    }
}
```

また、本リポジトリの `Deque` を使った実装とも比較しました。

```swift
func bfs(edges: [[Int]], startedAt start: Int, _ operation: (Int) -> Void) {
    precondition(edges.indices.contains(start), "`start` index is out of bounds: \(start)")
    var isVisited: [Bool] = .init(repeating: false, count: edges.count)
    var destinations: Deque<Int> = [start]
    while let current = destinations.popFirst() {
        if isVisited[current] { continue }
        operation(current)
        isVisited[current] = true
        for destination in edges[current] {
            destinations.append(destination)
        }
    }
}
```

しかし、 `testBFSPerformance` の結果は次の通りでした。

| 実装方式 | パフォーマンス (s) |
|:--|:--|
| `Array` 使い捨て | 0.023 |
| `ArraySlice` | 0.068 |
| `Deque` | 0.045 |

`testBFSPerformance` は単純な二分木に対するベンチマークなので対象となるグラフによって特性が異なる可能性がありますが（ノードあたりの分岐が多ければ多いほど「 `Array` 使い捨て」の allocation / deallocation コストの影響が大きくなるかもしれない）、~~ひとまず現状では「 `Array` 使い捨て」方式を採用します~~。

## 追記 2020-10-27 04:03

理論上は `ArraySlice` はリングバッファのインデックス計算のオーバーヘッドも allocation / deallocation のオーバーヘッドもなく最速に思えるのに遅いのが気になって、おそらく `ArraySlice` の実装固有の何らかのオーバーヘッドが存在するのだろうと考え、同じことを直接 `Array` で実装してみたところ、「 `Array` 追加捨て」よりも高速になりました。

| 実装方式 | パフォーマンス (s) |
|:--|:--|
| `Array` でキュー | 0.016 |

```swift
func bfs(edges: [[Int]], startedAt start: Int, _ operation: (Int) -> Void) {
    precondition(edges.indices.contains(start), "`start` index is out of bounds: \(start)")
    var isVisited: [Bool] = .init(repeating: false, count: edges.count)
    var destinations: [Int] = [start]
    destinations.reserveCapacity(edges.count)
    var i = 0
    while i < destinations.count {
        defer { i += 1 }
        let current = destinations[i]
        if isVisited[current] { continue }
        operation(current)
        isVisited[current] = true
        for destination in edges[current] {
            destinations.append(destination)
        }
    }
}
```

この方法および `ArraySlice` を使った方法はリングバッファに比べて多くのメモリを要しますが、~~高々ノード数分の領域を必要とするだけ~~なので、すでに `edges` や `isVisited` が存在していることを考えると問題にならないと考えられます。

## 追記 2020-10-27 22:51

単純なツリーでない場合、「高々ノード数分の領域を必要とするだけ」とはなりませんが、多くの場合はノード数の数倍程度におさまるのではないかと考えられます。

また、 `ArraySlice` の場合は `capacity` をキューとして使った場合、 `capacity` が無尽蔵に増大しないことがわかりました。おそらく、 `endIndex` が `capacity` を超えそうになったときに要素をコピーしてずらしているのではないかと思います。そうするとインデックスのオフセットが必要なので、 `ArraySlice` が遅かったのはその影響と、また `capacity` が小さいと頻繁にコピーが発生する影響だったのではないかと考えられます。