### PR TITLE
`NCR` の実装

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Swift Package 形式になっていますが、 AtCoder で利用する際には
 | Union-Find | `UnionFind` | [ARC 032 B - 道路工事](https://atcoder.jp/contests/arc032/submissions/17591100) |
 | mod | `ModInt` | [ARC 107 A - Simple Math](https://atcoder.jp/contests/arc107/submissions/17766344) |
 | 範囲の和 | `ClosedRange.sum(modulus:)` | [ARC 107 A - Simple Math](https://atcoder.jp/contests/arc107/submissions/17766344) |
+| nCr, mod | `NCR` | [ABC 151 E - Max-Min Sums](https://atcoder.jp/contests/abc151/submissions/17937622) |
 
 ## テスト
 

--- a/Sources/AtCoderSupport/NCR.swift
+++ b/Sources/AtCoderSupport/NCR.swift
@@ -1,0 +1,58 @@
+struct NCR {
+    let maxN: Int
+    let modulus: Int
+    private let factorials: [Int]
+    private let inverses: [Int]
+    private let inverseFactorials: [Int]
+    
+    init(maxN: Int, modulus: Int) {
+        precondition(maxN >= 0)
+        precondition(modulus >= 2)
+        var factorials: [Int] = [1, 1]
+        var inverses: [Int] = [1, 1]
+        var inverseFactorials: [Int] = [1, 1]
+        factorials.reserveCapacity(maxN + 1)
+        inverses.reserveCapacity(maxN + 1)
+        inverseFactorials.reserveCapacity(maxN + 1)
+        if maxN >= 2 {
+            for i in 2 ... maxN {
+                factorials.append(factorials[i - 1] * i % modulus)
+                inverses.append(modulus - inverses[modulus % i] * (modulus / i) % modulus)
+                inverseFactorials.append(inverseFactorials[i - 1] * inverses[i] % modulus)
+            }
+        }
+        
+        self.maxN = maxN
+        self.modulus = modulus
+        self.factorials = factorials
+        self.inverses = inverses
+        self.inverseFactorials = inverseFactorials
+    }
+    
+    func factorial(of n: Int) -> Int {
+        precondition(n >= 0)
+        precondition(n <= maxN)
+        return factorials[n]
+    }
+    
+    func npr(_ n: Int, _ r: Int) -> Int {
+        precondition(n >= 0)
+        precondition(n <= maxN)
+        precondition(r >= 0)
+        precondition(r <= n)
+        return factorials[n] * inverseFactorials[n - r] % modulus
+    }
+    
+    func ncr(_ n: Int, _ r: Int) -> Int {
+        precondition(n >= 0)
+        precondition(n <= maxN)
+        precondition(r >= 0)
+        precondition(r <= n)
+        return factorials[n] * (inverseFactorials[n - r] * inverseFactorials[r] % modulus) % modulus
+    }
+    
+    func callAsFunction(_ n: Int, _ r: Int) -> Int {
+        ncr(n, r)
+    }
+}
+

--- a/Tests/AtCoderSupportTests/NCRTests.swift
+++ b/Tests/AtCoderSupportTests/NCRTests.swift
@@ -1,0 +1,92 @@
+import XCTest
+@testable import AtCoderSupport
+
+final class NCRTests: XCTestCase {
+    func testFactorial() {
+        let a: NCR = .init(maxN: 10000, modulus: 998244353)
+        
+        XCTAssertEqual(a.factorial(of: 0), 1)
+        XCTAssertEqual(a.factorial(of: 1), 1)
+        XCTAssertEqual(a.factorial(of: 2), 2)
+        XCTAssertEqual(a.factorial(of: 3), 6)
+        XCTAssertEqual(a.factorial(of: 4), 24)
+        XCTAssertEqual(a.factorial(of: 5), 120)
+        XCTAssertEqual(a.factorial(of: 6), 720)
+        XCTAssertEqual(a.factorial(of: 7), 5_040)
+        XCTAssertEqual(a.factorial(of: 8), 40_320)
+        XCTAssertEqual(a.factorial(of: 9), 362_880)
+        
+        XCTAssertEqual(a.factorial(of: 18), 6_402_373_705_728_000 % 998244353)
+        
+        XCTAssertEqual(a.factorial(of: 10000), 777990065)
+    }
+    
+    func testNPR() {
+        let a: NCR = .init(maxN: 10000, modulus: 998244353)
+
+        XCTAssertEqual(a.npr(0, 0), 1)
+        XCTAssertEqual(a.npr(1, 1), 1)
+        XCTAssertEqual(a.npr(2, 2), 2)
+        XCTAssertEqual(a.npr(3, 3), 6)
+        XCTAssertEqual(a.npr(4, 4), 24)
+        XCTAssertEqual(a.npr(5, 5), 120)
+        XCTAssertEqual(a.npr(6, 6), 720)
+        XCTAssertEqual(a.npr(7, 7), 5_040)
+        XCTAssertEqual(a.npr(8, 8), 40_320)
+        XCTAssertEqual(a.npr(9, 9), 362_880)
+        
+        XCTAssertEqual(a.npr(18, 18), 6_402_373_705_728_000 % 998244353)
+        
+        for n in 0 ... 9 {
+            for r in 0 ... n {
+                XCTAssertEqual(a.npr(n, r), a.factorial(of: n) / a.factorial(of: n - r))
+            }
+        }
+        
+        XCTAssertEqual(a.npr(18, 7), 6_402_373_705_728_000 / 39_916_800 % 998244353)
+        
+        XCTAssertEqual(a.npr(10000, 2000), 168757127)
+    }
+    
+    func testNCR() {
+        let a: NCR = .init(maxN: 10000, modulus: 998244353)
+        
+        XCTAssertEqual(a.ncr(0, 0), 1)
+        
+        for n in 0 ... 9 {
+            for r in 0 ... n {
+                XCTAssertEqual(a.ncr(n, r), a.factorial(of: n) / (a.factorial(of: n - r) * a.factorial(of: r)))
+            }
+        }
+        
+        XCTAssertEqual(a.ncr(18, 7), 6_402_373_705_728_000 / (39_916_800 * 5_040) % 998244353)
+
+        XCTAssertEqual(a.ncr(10000, 2000), 96147199)
+        
+        XCTAssertEqual(a.ncr(10000, 0), 1)
+        XCTAssertEqual(a.ncr(10000, 1), 10000)
+        XCTAssertEqual(a.ncr(10000, 9999), 10000)
+        XCTAssertEqual(a.ncr(10000, 10000), 1)
+    }
+    
+    func testCallAsFunction() {
+        let ncr: NCR = .init(maxN: 10000, modulus: 998244353)
+        
+        XCTAssertEqual(ncr(0, 0), 1)
+        
+        for n in 0 ... 9 {
+            for r in 0 ... n {
+                XCTAssertEqual(ncr(n, r), ncr.factorial(of: n) / (ncr.factorial(of: n - r) * ncr.factorial(of: r)))
+            }
+        }
+        
+        XCTAssertEqual(ncr(18, 7), 6_402_373_705_728_000 / (39_916_800 * 5_040) % 998244353)
+
+        XCTAssertEqual(ncr(10000, 2000), 96147199)
+        
+        XCTAssertEqual(ncr(10000, 0), 1)
+        XCTAssertEqual(ncr(10000, 1), 10000)
+        XCTAssertEqual(ncr(10000, 9999), 10000)
+        XCTAssertEqual(ncr(10000, 10000), 1)
+    }
+}


### PR DESCRIPTION
高速に nCr を計算するために、 https://drken1215.hatenablog.com/entry/2018/06/08/210000 を `NCR` 型として実装しました。

`callAsFunction` を実装しているので、関数のように使うこともできます。

```swift
let ncr: NCR = .init(maxN: 10000, modulus: 998244353)
ncr(10000, 2000) // 96147199
```