### PR TITLE
`appendFirst` を `prepend` にリネーム

### DIFF
--- a/Sources/AtCoderSupport/Deque.swift
+++ b/Sources/AtCoderSupport/Deque.swift
@@ -30,9 +30,9 @@ struct Deque<Element>: MutableCollection, RandomAccessCollection, ExpressibleByA
         return buffer.popLast()
     }
     @discardableResult mutating func removeLast() -> Element { popLast()! }
-    mutating func appendFirst(_ element: Element) {
+    mutating func prepend(_ element: Element) {
         copyIfNeed()
-        buffer.appendFirst(element)
+        buffer.prepend(element)
     }
     mutating func popFirst() -> Element? {
         copyIfNeed()
@@ -105,7 +105,7 @@ struct Deque<Element>: MutableCollection, RandomAccessCollection, ExpressibleByA
             pointer.deinitialize(count: 1)
             return value
         }
-        func appendFirst(_ element: Element) {
+        func prepend(_ element: Element) {
             if count == capacity { doubleCapacity() }
             start = (start - 1 + capacity) % capacity
             buffer.advanced(by: start).initialize(to: element)

--- a/Tests/AtCoderSupportTests/DequeTests.swift
+++ b/Tests/AtCoderSupportTests/DequeTests.swift
@@ -34,10 +34,10 @@ final class DequeTests: XCTestCase {
         }
     }
 
-    func testAppendFirst() {
+    func testPrepend() {
         var deque: Deque<Int> = []
         for n in 1 ... 100 {
-            deque.appendFirst(n)
+            deque.prepend(n)
             XCTAssertEqual(deque.count, n)
             XCTAssertEqual(deque[0], n)
             XCTAssertEqual(deque[n - 1], 1)
@@ -78,7 +78,7 @@ final class DequeTests: XCTestCase {
                 if n.isMultiple(of: 2) {
                     deque.append(n)
                 } else {
-                    deque.appendFirst(n)
+                    deque.prepend(n)
                 }
             }
             XCTAssertEqual(deque.count, 1_000_000)


### PR DESCRIPTION
[Swift Collections](https://github.com/apple/swift-collections) が公開され、その中で `appendFirst` 相当のメソッドは `prepend` と命名されていたため、それに合わせてリネームした。