### PR TITLE
コピーして冗長に保持していた型の廃止

### DIFF
--- a/Sources/AtCoderSupport/Dijkstra.swift
+++ b/Sources/AtCoderSupport/Dijkstra.swift
@@ -1,3 +1,5 @@
+// ❗ 利用時に `PriorityQueue` のコピーが必要
+
 /// ダイクストラ法を用いて、始点となる頂点からグラフ中の各頂点への最短距離を求めます。
 ///
 /// - Parameters:
@@ -9,7 +11,7 @@
 func dijkstra<Distance>(graph: [[(index: Int, distance: Distance)]], startedAt start: Int) -> [Distance?] where Distance: Comparable, Distance: AdditiveArithmetic {
     var result: [Distance?] = .init(repeating: nil, count: graph.count)
     result[start] = .zero
-    var queue = _PriorityQueue<(Distance, Int)>(by: { $0.0 < $1.0 })
+    var queue = PriorityQueue<(Distance, Int)>(by: { $0.0 < $1.0 })
     queue.append((.zero, start))
     while let (totalDistanceToI, i) = queue.popFirst() {
         guard let minTotalDistanceToI = result[i] else { preconditionFailure("Never reaches here.") }
@@ -30,68 +32,4 @@ func dijkstra<Distance>(graph: [[(index: Int, distance: Distance)]], startedAt s
         }
     }
     return result
-}
-private struct _PriorityQueue<Element> {
-    private var elements: [Element] = []
-    private let areInIncreasingOrder: (Element, Element) -> Bool
-    
-    init<S>(_ elements: S, by areInIncreasingOrder: @escaping (Element, Element) -> Bool) where S: Sequence, S.Element == Element {
-        self.areInIncreasingOrder = areInIncreasingOrder
-        for element in elements {
-            append(element)
-        }
-    }
-    
-    init(by areInIncreasingOrder: @escaping (Element, Element) -> Bool) {
-        self.init(EmptyCollection(), by: areInIncreasingOrder)
-    }
-    
-    var isEmpty: Bool { elements.isEmpty }
-    var count: Int { elements.count }
-    var first: Element? { elements.first }
-    
-    mutating func append(_ element: Element) {
-        var i = elements.count
-        elements.append(element)
-        elements.withUnsafeMutableBufferPointer { elements in
-            while i > 0 {
-                let parentIndex = (i - 1) >> 1
-                let parent = elements[parentIndex]
-                guard areInIncreasingOrder(element, parent) else { break }
-                elements[parentIndex] = element
-                elements[i] = parent
-                i = parentIndex
-            }
-        }
-    }
-    
-    mutating func popFirst() -> Element? {
-        guard let element = elements.popLast() else { return nil }
-        guard let first = elements.first else { return element }
-        
-        elements.withUnsafeMutableBufferPointer { elements in
-            elements[0] = element
-            
-            var  i = 0
-            while true {
-                var childIndex: Int = (i << 1) + 1
-                guard childIndex < elements.count else { break }
-                var child: Element = elements[childIndex]
-                let rightIndex = childIndex + 1
-                if rightIndex < elements.count {
-                    let right = elements[rightIndex]
-                    if areInIncreasingOrder(right, child) {
-                        childIndex = rightIndex
-                        child = right
-                    }
-                }
-                if areInIncreasingOrder(element, child) { break }
-                elements[childIndex] = element
-                elements[i] = child
-                i = childIndex
-            }
-        }
-
-        return first
-    }
 }


### PR DESCRIPTION
`dijkstra` を 1 ファイルでコピーして使えるように、 `PriorityQueue` を Dijkstra.swift にコピーして `_PriorityQueue` として保持していた。しかし、これは改変が発生したときにコピー元とコピー先でコードの乖離を招きかねない。

この後、 BFS を `Deque` を利用した実装に戻そうと考えているが、そうなると `bfs` と `Deque` にも同じことが言える。 `bfs` でも `_Deque` を作るのは避けたいので `_PriorityQueue` を廃止する。