### PR TITLE
readInt*におけるSubstring→Intの変換をStringを介するように修正

### DIFF
--- a/Sources/AtCoderSupport/Input.swift
+++ b/Sources/AtCoderSupport/Input.swift
@@ -1,64 +1,25 @@
-func readInt1(line: Int = #line, file: String = #file) -> Int {
-    guard let string = readLine() else {
-        preconditionFailure("No input (at line \(line) in \(file))")
-    }
-    guard let value = Int(string) else {
-        preconditionFailure("Illegal input value: \(string) (at line \(line) in \(file))")
-    }
-    return value
+func readInt1() -> Int {
+    Int(readLine()!)!
 }
 
-func readInt2(line: Int = #line, file: String = #file) -> (Int, Int) {
-    guard let string = readLine() else {
-        preconditionFailure("No input (at line \(line) in \(file))")
-    }
-    let values: [Int] = string.split(separator: " ").map { part in
-        guard let value = Int(part) else {
-            preconditionFailure("Illegal input value: \(string) (at line \(line) in \(file))")
-        }
-        return value
-    }
-    precondition(values.count == 2, "Illegal number of input values: count = \(values.count), values = \(values) (at line \(line) in \(file))")
+func readInt2() -> (Int, Int) {
+    let values = readLine()!.split(separator: " ").map { Int(String($0))! }
+    precondition(values.count == 2)
     return (values[0], values[1])
 }
 
 func readInt3(line: Int = #line, file: String = #file) -> (Int, Int, Int) {
-    guard let string = readLine() else {
-        preconditionFailure("No input (at line \(line) in \(file))")
-    }
-    let values: [Int] = string.split(separator: " ").map { part in
-        guard let value = Int(part) else {
-            preconditionFailure("Illegal input value: \(string) (at line \(line) in \(file))")
-        }
-        return value
-    }
-    precondition(values.count == 3, "Illegal number of input values: count = \(values.count), values = \(values) (at line \(line) in \(file))")
+    let values = readLine()!.split(separator: " ").map { Int(String($0))! }
+    precondition(values.count == 3)
     return (values[0], values[1], values[2])
 }
 
 func readInt4(line: Int = #line, file: String = #file) -> (Int, Int, Int, Int) {
-    guard let string = readLine() else {
-        preconditionFailure("No input (at line \(line) in \(file))")
-    }
-    let values: [Int] = string.split(separator: " ").map { part in
-        guard let value = Int(part) else {
-            preconditionFailure("Illegal input value: \(string) (at line \(line) in \(file))")
-        }
-        return value
-    }
-    precondition(values.count == 4, "Illegal number of input values: count = \(values.count), values = \(values) (at line \(line) in \(file))")
+    let values = readLine()!.split(separator: " ").map { Int(String($0))! }
+    precondition(values.count == 4)
     return (values[0], values[1], values[2], values[3])
 }
 
 func readIntN(line: Int = #line, file: String = #file) -> [Int] {
-    guard let string = readLine() else {
-        preconditionFailure("No input (at line \(line) in \(file))")
-    }
-    let values: [Int] = string.split(separator: " ").map { part in
-        guard let value = Int(part) else {
-            preconditionFailure("Illegal input value: \(string) (at line \(line) in \(file))")
-        }
-        return value
-    }
-    return values
+    readLine()!.split(separator: " ").map { Int(String($0))! }
 }


### PR DESCRIPTION
`Substring` を `Int` に直接変換すると遅い。一度 `Substring` を `String` に変換してから `Int` に変換した方が高速。この問題が [ABC 210 D](https://atcoder.jp/contests/abc210/tasks/abc210_d) で顕在化した。

参考:
- https://twitter.com/koher/status/1416428612056621071
- https://discord.com/channels/291054398077927425/291054454793306112/865991382426714122

併せて `readInt*` の実装を単純化した。これまでは `#file` や `#line` を利用してエラー時にエラーメッセージを表示するようにしていたが、それらが役に立ったことがないため、コードが読みやすい方が役に立つと判断した。