### PR TITLE
bfsの実装をDequeを使ったものに変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Swift Package 形式になっていますが、 AtCoder で利用する際には
 | nCr | `NCR` | [ABC 151 E - Max-Min Sums](https://atcoder.jp/contests/abc151/submissions/17937622) |
 | 二分探索 | `values(_:_:)` | [ABC 077 C - Snuke Festival](https://atcoder.jp/contests/abc077/submissions/17547635) |
 | 深さ優先探索 | `dfs(edges:startedAt:_:)` | [ABC 138 D - Ki](https://atcoder.jp/contests/abc138/submissions/17661705) |
+| 幅優先探索 | `bfs(edges:startedAt:,_:)` | [ABC 190 E - Magical Ornament](https://atcoder.jp/contests/abc190/submissions/24337525) |
 | 素数判定 | `isPrime` | [ABC 149 C - Next Prime](https://atcoder.jp/contests/abc149/submissions/17548101) |
 | ベルマン–フォード法 | `bellmanFord(graph:startedAt)` | [ABC 061 D - Score Attack](https://atcoder.jp/contests/abc061/submissions/18111027) |
 | ダイクストラ法 | `dijkstra(graph:startedAt:)` | [ABC 035 D - トレジャーハント](https://atcoder.jp/contests/abc035/submissions/17662367) |

--- a/Sources/AtCoderSupport/BFS.swift
+++ b/Sources/AtCoderSupport/BFS.swift
@@ -1,12 +1,10 @@
+// ❗ 利用時に `Deque` のコピーが必要
+
 func bfs(edges: [[Int]], startedAt start: Int, _ operation: (Int) -> Void) {
     precondition(edges.indices.contains(start), "`start` index is out of bounds: \(start)")
     var isVisited: [Bool] = .init(repeating: false, count: edges.count)
-    var destinations: [Int] = [start]
-    destinations.reserveCapacity(edges.count)
-    var i = 0
-    while i < destinations.count {
-        defer { i += 1 }
-        let current = destinations[i]
+    var destinations: Deque<Int> = [start]
+    while let current = destinations.popFirst() {
         if isVisited[current] { continue }
         operation(current)
         isVisited[current] = true
@@ -19,12 +17,8 @@ func bfs(edges: [[Int]], startedAt start: Int, _ operation: (Int) -> Void) {
 func bfs(edges: [[Int]], startedAt start: Int, _ operation: (_ current: Int, _ prev: Int?) -> Void) {
     precondition(edges.indices.contains(start), "`start` index is out of bounds: \(start)")
     var isVisited: [Bool] = .init(repeating: false, count: edges.count)
-    var destinations: [(current: Int, prev: Int?)] = [(start, nil)]
-    destinations.reserveCapacity(edges.count)
-    var i = 0
-    while i < destinations.count {
-        defer { i += 1 }
-        let (current, prev) = destinations[i]
+    var destinations: Deque<(current: Int, prev: Int?)> = [(start, nil)]
+    while let (current, prev) = destinations.popFirst() {
         if isVisited[current] { continue }
         operation(current, prev)
         isVisited[current] = true
@@ -37,12 +31,8 @@ func bfs(edges: [[Int]], startedAt start: Int, _ operation: (_ current: Int, _ p
 func bfs(edges: [[Int]], startedAt start: Int, _ operation: (_ current: Int, _ prev: Int?, _ depth: Int) -> Void) {
     precondition(edges.indices.contains(start), "`start` index is out of bounds: \(start)")
     var isVisited: [Bool] = .init(repeating: false, count: edges.count)
-    var destinations: [(current: Int, prev: Int?, depth: Int)] = [(start, nil, 0)]
-    destinations.reserveCapacity(edges.count)
-    var i = 0
-    while i < destinations.count {
-        defer { i += 1 }
-        let (current, prev, depth) = destinations[i]
+    var destinations: Deque<(current: Int, prev: Int?, depth: Int)> = [(start, nil, 0)]
+    while let (current, prev, depth) = destinations.popFirst() {
         if isVisited[current] { continue }
         operation(current, prev, depth)
         isVisited[current] = true


### PR DESCRIPTION
幅優先探索は関数をそのまま利用するだけでなく、問題に合わせて変更しながら利用することも多い。そのため、わずかなパフォーマンス上の優位性よりもコードの可読性が重要である。 `Deque` を利用する実装はより素直なため、それを採用した。